### PR TITLE
Make Hash and Set keys separate from each other

### DIFF
--- a/src/Hangfire.Console/Storage/ConsoleStorage.cs
+++ b/src/Hangfire.Console/Storage/ConsoleStorage.cs
@@ -61,7 +61,7 @@ namespace Hangfire.Console.Storage
                 {
                     var referenceKey = Guid.NewGuid().ToString("N");
 
-                    tran.SetRangeInHash(consoleId.ToString(), new[] { new KeyValuePair<string, string>(referenceKey, line.Message) });
+                    tran.SetRangeInHash(GetHashKey(consoleId), new[] { new KeyValuePair<string, string>(referenceKey, line.Message) });
 
                     line.Message = referenceKey;
                     line.IsReference = true;
@@ -69,7 +69,7 @@ namespace Hangfire.Console.Storage
                     value = JobHelper.ToJson(line);
                 }
 
-                tran.AddToSet(consoleId.ToString(), value);
+                tran.AddToSet(GetSetKey(consoleId), value);
 
                 tran.Commit();
             }
@@ -82,8 +82,15 @@ namespace Hangfire.Console.Storage
 
             using (var tran = (JobStorageTransaction)_connection.CreateWriteTransaction())
             {
-                tran.ExpireSet(consoleId.ToString(), expireIn);
-                tran.ExpireHash(consoleId.ToString(), expireIn);
+                tran.ExpireSet(GetSetKey(consoleId), expireIn);
+                tran.ExpireHash(GetHashKey(consoleId), expireIn);
+
+                // After upgrading to Hangfire.Console version with new keys, 
+                // there may be existing background jobs with console attached 
+                // to the previous keys. We should expire them also.
+                tran.ExpireSet(GetOldConsoleKey(consoleId), expireIn);
+                tran.ExpireHash(GetOldConsoleKey(consoleId), expireIn);
+
                 tran.Commit();
             }
         }
@@ -93,7 +100,16 @@ namespace Hangfire.Console.Storage
             if (consoleId == null)
                 throw new ArgumentNullException(nameof(consoleId));
 
-            return (int)_connection.GetSetCount(consoleId.ToString());
+            var result = (int)_connection.GetSetCount(GetSetKey(consoleId));
+
+            if (result == 0)
+            {
+                // Read operations should be backwards compatible and use
+                // old keys, if new one don't contain any data.
+                return (int)_connection.GetSetCount(GetOldConsoleKey(consoleId));
+            }
+
+            return result;
         }
 
         public IEnumerable<ConsoleLine> GetLines(ConsoleId consoleId, int start, int end)
@@ -101,13 +117,26 @@ namespace Hangfire.Console.Storage
             if (consoleId == null)
                 throw new ArgumentNullException(nameof(consoleId));
 
-            foreach (var item in _connection.GetRangeFromSet(consoleId.ToString(), start, end))
+            var useOldKeys = false;
+            var items = _connection.GetRangeFromSet(GetSetKey(consoleId), start, end);
+
+            if (items == null || items.Count == 0)
+            {
+                // Read operations should be backwards compatible and use
+                // old keys, if new one don't contain any data.
+                items = _connection.GetRangeFromSet(GetOldConsoleKey(consoleId), start, end);
+                useOldKeys = true;
+            }
+
+            foreach (var item in items)
             {
                 var line = JobHelper.FromJson<ConsoleLine>(item);
 
                 if (line.IsReference)
                 {
-                    line.Message = _connection.GetValueFromHash(consoleId.ToString(), line.Message);
+                    line.Message = useOldKeys
+                        ? _connection.GetValueFromHash(GetOldConsoleKey(consoleId), line.Message)
+                        : _connection.GetValueFromHash(GetHashKey(consoleId), line.Message);
                     line.IsReference = false;
                 }
 
@@ -121,6 +150,21 @@ namespace Hangfire.Console.Storage
                 throw new ArgumentNullException(nameof(consoleId));
 
             return _connection.GetStateData(consoleId.JobId);
+        }
+
+        private string GetSetKey(ConsoleId consoleId)
+        {
+            return $"console:{consoleId}";
+        }
+
+        private string GetHashKey(ConsoleId consoleId)
+        {
+            return $"console:refs:{consoleId}";
+        }
+
+        private string GetOldConsoleKey(ConsoleId consoleId)
+        {
+            return consoleId.ToString();
         }
     }
 }

--- a/src/Hangfire.Console/Storage/ConsoleStorage.cs
+++ b/src/Hangfire.Console/Storage/ConsoleStorage.cs
@@ -134,9 +134,24 @@ namespace Hangfire.Console.Storage
 
                 if (line.IsReference)
                 {
-                    line.Message = useOldKeys
-                        ? _connection.GetValueFromHash(GetOldConsoleKey(consoleId), line.Message)
-                        : _connection.GetValueFromHash(GetHashKey(consoleId), line.Message);
+                    if (useOldKeys)
+                    {
+                        try
+                        {
+                            line.Message = _connection.GetValueFromHash(GetOldConsoleKey(consoleId), line.Message);
+                        }
+                        catch
+                        {
+                            // This may happen, when using Hangfire.Redis storage and having
+                            // background job, whose console session was stored using old key
+                            // format.
+                        }
+                    }
+                    else
+                    {
+                        line.Message = _connection.GetValueFromHash(GetHashKey(consoleId), line.Message);
+                    }
+                    
                     line.IsReference = false;
                 }
 

--- a/tests/Hangfire.Console.Tests/Storage/ConsoleStorageFacts.cs
+++ b/tests/Hangfire.Console.Tests/Storage/ConsoleStorageFacts.cs
@@ -7,7 +7,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Hangfire.Console.Tests.Storage
@@ -79,8 +78,8 @@ namespace Hangfire.Console.Tests.Storage
             storage.AddLine(_consoleId, line);
 
             Assert.False(line.IsReference);
-            _transaction.Verify(x => x.AddToSet(It.IsAny<string>(), It.IsAny<string>()));
-            _transaction.Verify(x => x.SetRangeInHash(It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()), Times.Never);
+            _transaction.Verify(x => x.AddToSet($"console:{_consoleId}", It.IsAny<string>()));
+            _transaction.Verify(x => x.SetRangeInHash($"console:refs:{_consoleId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>()), Times.Never);
         }
 
         [Fact]
@@ -99,8 +98,8 @@ namespace Hangfire.Console.Tests.Storage
             storage.AddLine(_consoleId, line);
 
             Assert.True(line.IsReference);
-            _transaction.Verify(x => x.AddToSet(It.IsAny<string>(), It.IsAny<string>()));
-            _transaction.Verify(x => x.SetRangeInHash(It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>()));
+            _transaction.Verify(x => x.AddToSet($"console:{_consoleId}", It.IsAny<string>()));
+            _transaction.Verify(x => x.SetRangeInHash($"console:refs:{_consoleId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>()));
         }
 
         [Fact]
@@ -118,8 +117,19 @@ namespace Hangfire.Console.Tests.Storage
 
             storage.Expire(_consoleId, TimeSpan.FromHours(1));
 
-            _transaction.Verify(x => x.ExpireSet(It.IsAny<string>(), It.IsAny<TimeSpan>()));
-            _transaction.Verify(x => x.ExpireHash(It.IsAny<string>(), It.IsAny<TimeSpan>()));
+            _transaction.Verify(x => x.ExpireSet($"console:{_consoleId}", It.IsAny<TimeSpan>()));
+            _transaction.Verify(x => x.ExpireHash($"console:refs:{_consoleId}", It.IsAny<TimeSpan>()));
+        }
+
+        [Fact]
+        public void Expire_ExpiresOldSetAndHashKeysEither_ForBackwardsCompatibility()
+        {
+            var storage = new ConsoleStorage(_connection.Object);
+
+            storage.Expire(_consoleId, TimeSpan.FromHours(1));
+
+            _transaction.Verify(x => x.ExpireSet(_consoleId.ToString(), It.IsAny<TimeSpan>()));
+            _transaction.Verify(x => x.ExpireHash(_consoleId.ToString(), It.IsAny<TimeSpan>()));
         }
 
         [Fact]
@@ -133,8 +143,21 @@ namespace Hangfire.Console.Tests.Storage
         [Fact]
         public void GetLineCount_ReturnsCountOfSet()
         {
-            _connection.Setup(x => x.GetSetCount(It.IsAny<string>()))
+            _connection.Setup(x => x.GetSetCount($"console:{_consoleId}"))
                 .Returns(123);
+
+            var storage = new ConsoleStorage(_connection.Object);
+
+            var count = storage.GetLineCount(_consoleId);
+
+            Assert.Equal(123, count);
+        }
+
+        [Fact]
+        public void GetLineCount_ReturnsCountOfOldSet_WhenNewOneReturnsZero_ForBackwardsCompatibility()
+        {
+            _connection.Setup(x => x.GetSetCount($"console:{_consoleId}")).Returns(0);
+            _connection.Setup(x => x.GetSetCount(_consoleId.ToString())).Returns(123);
 
             var storage = new ConsoleStorage(_connection.Object);
 
@@ -161,7 +184,27 @@ namespace Hangfire.Console.Tests.Storage
                 new ConsoleLine { TimeOffset = 3, Message = "line4" },
             };
 
-            _connection.Setup(x => x.GetRangeFromSet(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            _connection.Setup(x => x.GetRangeFromSet($"console:{_consoleId}", It.IsAny<int>(), It.IsAny<int>()))
+                .Returns((string key, int start, int end) => lines.Where((x, i) => i >= start && i <= end).Select(JobHelper.ToJson).ToList());
+
+            var storage = new ConsoleStorage(_connection.Object);
+
+            var result = storage.GetLines(_consoleId, 1, 2).ToArray();
+
+            Assert.Equal(lines.Skip(1).Take(2).Select(x => x.Message), result.Select(x => x.Message));
+        }
+
+        [Fact]
+        public void GetLines_ReturnsRangeFromOldSet_ForBackwardsCompatibility()
+        {
+            var lines = new[] {
+                new ConsoleLine { TimeOffset = 0, Message = "line1" },
+                new ConsoleLine { TimeOffset = 1, Message = "line2" },
+                new ConsoleLine { TimeOffset = 2, Message = "line3" },
+                new ConsoleLine { TimeOffset = 3, Message = "line4" },
+            };
+
+            _connection.Setup(x => x.GetRangeFromSet(_consoleId.ToString(), It.IsAny<int>(), It.IsAny<int>()))
                 .Returns((string key, int start, int end) => lines.Where((x, i) => i >= start && i <= end).Select(JobHelper.ToJson).ToList());
 
             var storage = new ConsoleStorage(_connection.Object);
@@ -178,9 +221,29 @@ namespace Hangfire.Console.Tests.Storage
                 new ConsoleLine { TimeOffset = 0, Message = "line1", IsReference = true }
             };
 
-            _connection.Setup(x => x.GetRangeFromSet(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            _connection.Setup(x => x.GetRangeFromSet($"console:{_consoleId}", It.IsAny<int>(), It.IsAny<int>()))
                 .Returns((string key, int start, int end) => lines.Where((x, i) => i >= start && i <= end).Select(JobHelper.ToJson).ToList());
-            _connection.Setup(x => x.GetValueFromHash(It.IsAny<string>(), It.IsAny<string>()))
+            _connection.Setup(x => x.GetValueFromHash($"console:refs:{_consoleId}", It.IsAny<string>()))
+                .Returns("Dereferenced Line");
+
+            var storage = new ConsoleStorage(_connection.Object);
+
+            var result = storage.GetLines(_consoleId, 0, 1).Single();
+
+            Assert.False(result.IsReference);
+            Assert.Equal("Dereferenced Line", result.Message);
+        }
+
+        [Fact]
+        public void GetLines_ExpandsReferencesFromOldHash_ForBackwardsCompatibility()
+        {
+            var lines = new[] {
+                new ConsoleLine { TimeOffset = 0, Message = "line1", IsReference = true }
+            };
+
+            _connection.Setup(x => x.GetRangeFromSet(_consoleId.ToString(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns((string key, int start, int end) => lines.Where((x, i) => i >= start && i <= end).Select(JobHelper.ToJson).ToList());
+            _connection.Setup(x => x.GetValueFromHash(_consoleId.ToString(), It.IsAny<string>()))
                 .Returns("Dereferenced Line");
 
             var storage = new ConsoleStorage(_connection.Object);


### PR DESCRIPTION
Some storages, like Hangfire.Redis have single key space for all data types, including hashes and sets, due to historical reasons. When we try to store values of different types within the same key, an
exception could be thrown, for example:

![image](https://cloud.githubusercontent.com/assets/1078718/21317983/6e8f95be-c618-11e6-9a99-e41b3fdf0fca.png)

This PR solves this issue by using separate keys for sets and hashes that are used by Hangfire.Console: `console:{consoleId}` for sets and `console:refs:{consoleId}` for hashes. 

Despite of we can keep sets in an old format (just `{consoleId}`), I've decided to add prefixes to keep data related to Hangfire.Console separate from others. IMHO this makes it easier to investigate what feature produced those keys. If you don't agree with this due to performance reasons, I can make all the required modifications.