### PR TITLE
Adding support for HTML logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+/nuget

--- a/src/Hangfire.Console/ConsoleExtensions.cs
+++ b/src/Hangfire.Console/ConsoleExtensions.cs
@@ -50,6 +50,16 @@ namespace Hangfire.Console
         }
 
         /// <summary>
+        /// Adds a HTML string to console.
+        /// </summary>
+        /// <param name="context">Context</param>
+        /// <param name="value">String</param>
+        public static void WriteHtmlLine(this PerformContext context, string value)
+        {
+            ConsoleContext.FromPerformContext(context)?.WriteHtmlLine(value);
+        }
+
+        /// <summary>
         /// Adds a string to console.
         /// </summary>
         /// <param name="context">Context</param>

--- a/src/Hangfire.Console/Dashboard/ConsoleRenderer.cs
+++ b/src/Hangfire.Console/Dashboard/ConsoleRenderer.cs
@@ -59,7 +59,10 @@ namespace Hangfire.Console.Dashboard
             }
             else
             {
-                builder.Append(Helper.HtmlEncode(line.Message));
+                if (line.IsHtml)
+                    builder.Append(line.Message);
+                else
+                    builder.Append(Helper.HtmlEncode(line.Message));
             }
 
             builder.Append("</div>");

--- a/src/Hangfire.Console/Serialization/ConsoleLine.cs
+++ b/src/Hangfire.Console/Serialization/ConsoleLine.cs
@@ -17,6 +17,12 @@ namespace Hangfire.Console.Serialization
         public bool IsReference { get; set; }
 
         /// <summary>
+        /// True if <see cref="Message"/> is a Hash reference.
+        /// </summary>
+        [JsonProperty("h", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool IsHtml { get; set; }
+
+        /// <summary>
         /// Message text, or message reference, or progress bar id
         /// </summary>
         [JsonProperty("s", Required = Required.Always)]

--- a/src/Hangfire.Console/Server/ConsoleContext.cs
+++ b/src/Hangfire.Console/Server/ConsoleContext.cs
@@ -70,6 +70,11 @@ namespace Hangfire.Console.Server
             AddLine(new ConsoleLine() { Message = value ?? "", TextColor = TextColor });
         }
 
+        public void WriteHtmlLine(string value)
+        {
+            AddLine(new ConsoleLine() { Message = value ?? "", TextColor = TextColor, IsHtml = true });
+        }
+
         public IProgressBar WriteProgressBar(int value, ConsoleTextColor color)
         {
             var progressBarId = Interlocked.Increment(ref _nextProgressBarId);


### PR DESCRIPTION
Potential fix for issue https://github.com/pieceofsummer/Hangfire.Console/issues/14.

Allows the use of context.WriteHtmlLine(string message) in order to write raw (unencoded) HTML to the dashboard for use of links etc.

Sample image below using WriteHtmlLine to insert a link to elasticsearch query through Kibana to display all the structured log messaged from this Hangfire job.

![image](https://cloud.githubusercontent.com/assets/20848495/22049487/1956c890-dcf9-11e6-9d47-1ea0118cc433.png)
