### PR TITLE
Added WithProgressIncrements extension methods

### DIFF
--- a/src/Hangfire.Console/EnumerableExtensions.cs
+++ b/src/Hangfire.Console/EnumerableExtensions.cs
@@ -54,5 +54,53 @@ namespace Hangfire.Console
 
             return new ProgressEnumerable(enumerable, progressBar, count);
         }
+
+        /// <summary>
+        /// Returns a <see cref="IEnumerable{T}"/> reporting enumeration progress.
+        /// </summary>
+        /// <typeparam name="T">Item type</typeparam>
+        /// <param name="enumerable">Source enumerable</param>
+        /// <param name="progressBar">Progress bar</param>
+        /// <param name="percentageIncrementStep">Minimum percentage step, controls frequency of updates</param>
+        /// <param name="count">Item count</param>
+        /// <returns></returns>
+        public static IEnumerable<T> WithProgressIncrements<T>(this IEnumerable<T> enumerable, IProgressBar progressBar, int percentageIncrementStep, int count = -1)
+        {
+            if (enumerable is ICollection<T>)
+            {
+                count = ((ICollection<T>)enumerable).Count;
+            }
+            else if (enumerable is IReadOnlyCollection<T>)
+            {
+                count = ((IReadOnlyCollection<T>)enumerable).Count;
+            }
+            else if (count < 0)
+            {
+                throw new ArgumentException("Count is required when enumerable is not a collection", nameof(count));
+            }
+
+            return new ProgressEnumerable<T>(enumerable, progressBar, count, percentageIncrementStep);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="IEnumerable"/> reporting enumeration progress.
+        /// </summary>
+        /// <param name="enumerable">Source enumerable</param>
+        /// <param name="progressBar">Progress bar</param>
+        /// <param name="percentageIncrementStep">Minimum percentage step, controls frequency of updates</param>
+        /// <param name="count">Item count</param>
+        public static IEnumerable WithProgressIncrements(this IEnumerable enumerable, IProgressBar progressBar, int percentageIncrementStep, int count = -1)
+        {
+            if (enumerable is ICollection)
+            {
+                count = ((ICollection)enumerable).Count;
+            }
+            else if (count < 0)
+            {
+                throw new ArgumentException("Count is required when enumerable is not a collection", nameof(count));
+            }
+
+            return new ProgressEnumerable(enumerable, progressBar, count, percentageIncrementStep);
+        }
     }
 }

--- a/tests/Hangfire.Console.Tests/ConsoleExtensionsFacts.cs
+++ b/tests/Hangfire.Console.Tests/ConsoleExtensionsFacts.cs
@@ -6,6 +6,7 @@ using Hangfire.Server;
 using Hangfire.Storage;
 using Moq;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Hangfire.Console.Tests
@@ -74,6 +75,25 @@ namespace Hangfire.Console.Tests
             
             Assert.IsType<DefaultProgressBar>(progressBar);
             _transaction.Verify(x => x.Commit());
+        }
+
+        [Fact]
+        public void WithProgressBarIncrements_CommitsGivenTimes_IfConsoleCreated()
+        {
+            var context = CreatePerformContext();
+            context.Items["ConsoleContext"] = CreateConsoleContext(context);
+
+            var progressBar = ConsoleExtensions.WriteProgressBar(context);
+            int[] numbers = Enumerable.Repeat(1, 1000).ToArray();
+
+            foreach (int num in numbers.WithProgressIncrements(progressBar, 5))
+            {
+                // do something, don't want the loop being optimised out
+                System.Diagnostics.Debug.Write(num);
+            }
+
+            Assert.IsType<DefaultProgressBar>(progressBar);
+            _transaction.Verify(x => x.Commit(), Times.Exactly(21));
         }
 
         [Fact]


### PR DESCRIPTION
 ...to allow more course grained control over the number of transaction commits/updates being performed especially with loops > 1000 iterations, as this will result in 1000 tx commits. On low resource (1 core, SQL Express) cloud computing instances this can lead to Hangfire not getting the heartbeat response within timeout, causing jobs to be abandoned and restarted.