### PR TITLE
Don't throw exception on already initialized

### DIFF
--- a/src/Hangfire.Console/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Console/GlobalConfigurationExtensions.cs
@@ -28,8 +28,9 @@ namespace Hangfire.Console
 
             options.Validate(nameof(options));
 
-            if (DashboardRoutes.Routes.Contains("/console/([0-9a-f]{11}.+)"))
-                throw new InvalidOperationException("Console is already initialized");
+            var isAlreadyInitialized = DashboardRoutes.Routes.Contains("/console/([0-9a-f]{11}.+)")
+            if (isAlreadyInitialized)
+                return configuration;
 
             // register server filter for jobs
             GlobalJobFilters.Filters.Add(new ConsoleServerFilter(options));


### PR DESCRIPTION
This makes it very painful to write integration tests using the preferred method (TestServer) in ASP .NET Core.

Because the statics are not cleaned up, we can't prevent the issue either in a pretty manner.

Besides, if you are configuring your stuff twice, you would already be having bigger issues.