### PR TITLE
-1 sent to UI 1- when culture has a right to left language

### DIFF
--- a/src/Hangfire.Console/Dashboard/JobProgressDispatcher.cs
+++ b/src/Hangfire.Console/Dashboard/JobProgressDispatcher.cs
@@ -19,7 +19,8 @@ namespace Hangfire.Console.Dashboard
     {
         internal static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings()
         {
-            ContractResolver = new DefaultContractResolver()
+            ContractResolver = new DefaultContractResolver(),
+            Culture = System.Globalization.CultureInfo.InvariantCulture
         };
         
         // ReSharper disable once NotAccessedField.Local


### PR DESCRIPTION
This issue will appear when your culture has language Right To Left. 
And the result of **parseInt** is **NaN** (check the image below).
![image](https://user-images.githubusercontent.com/30401/134039335-9ce635a8-baea-4bac-ba19-3809335a9b63.png)

As a work around I customized the culture in my App as follows:
```csharp
culture.NumberFormat = NumberFormatInfo.InvariantInfo;
```
