### PR TITLE
Fixing Right To Left Culture .net5 issue

### DIFF
--- a/src/Hangfire.Console/Dashboard/ConsoleRenderer.cs
+++ b/src/Hangfire.Console/Dashboard/ConsoleRenderer.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Hangfire.Console.Dashboard
 {
@@ -23,7 +24,7 @@ namespace Hangfire.Console.Dashboard
         private static readonly Regex LinkDetector = new Regex(@"
             \b(?:(?<schema>(?:f|ht)tps?://)|www\.|ftp\.)
               (?:\([-\w+&@#/%=~|$?!:,.]*\)|[-\w+&@#/%=~|$?!:,.])*
-              (?:\([-\w+&@#/%=~|$?!:,.]*\)|[\w+&@#/%=~|$])", 
+              (?:\([-\w+&@#/%=~|$?!:,.]*\)|[\w+&@#/%=~|$])",
             RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private class DummyPage : RazorPage
@@ -41,7 +42,7 @@ namespace Hangfire.Console.Dashboard
         public static void RenderText(StringBuilder buffer, string text)
         {
             if (string.IsNullOrEmpty(text)) return;
-            
+
             var start = 0;
 
             foreach (Match m in LinkDetector.Matches(text))
@@ -136,7 +137,7 @@ namespace Hangfire.Console.Dashboard
                 RenderLine(builder, line, timestamp);
             }
         }
-        
+
         /// <summary>
         /// Fetches and renders console line buffer.
         /// </summary>
@@ -155,10 +156,36 @@ namespace Hangfire.Console.Dashboard
 
             var items = ReadLines(storage, consoleId, ref start);
 
+#if NETSTANDARD2_0
+            FixRightToLeftNumberFormat();
+#endif
+
             builder.AppendFormat("<div class=\"line-buffer\" data-n=\"{1}\">", consoleId, start);
             RenderLines(builder, items, consoleId.DateValue);
             builder.Append("</div>");
         }
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Making sure that -1 will not be sent to UI 1-, this issue appears in net5 and above.
+        /// </summary>
+        private static void FixRightToLeftNumberFormat()
+        {
+            if (CultureInfo.CurrentCulture.TextInfo.IsRightToLeft)
+            {
+                if (CultureInfo.CurrentCulture.IsReadOnly)
+                {
+                    var clone = CultureInfo.CurrentCulture.Clone() as CultureInfo;
+                    clone.NumberFormat = NumberFormatInfo.InvariantInfo;
+                    CultureInfo.CurrentCulture = clone;
+                }
+                else
+                {
+                    CultureInfo.CurrentCulture.NumberFormat = NumberFormatInfo.InvariantInfo;
+                }
+            }
+        }
+#endif
 
         /// <summary>
         /// Fetches console lines from storage.
@@ -182,7 +209,7 @@ namespace Hangfire.Console.Dashboard
                 // has some new items to fetch
 
                 Dictionary<string, ConsoleLine> progressBars = null;
-                    
+
                 foreach (var entry in storage.GetLines(consoleId, start, count - 1))
                 {
                     if (entry.ProgressValue.HasValue)

--- a/src/Hangfire.Console/Dashboard/ConsoleRenderer.cs
+++ b/src/Hangfire.Console/Dashboard/ConsoleRenderer.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace Hangfire.Console.Dashboard
 {

--- a/src/Hangfire.Console/Hangfire.Console.csproj
+++ b/src/Hangfire.Console/Hangfire.Console.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Hangfire.Console</AssemblyTitle>
     <VersionPrefix>1.4.2</VersionPrefix>
     <Authors>Alexey Skalozub</Authors>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Hangfire.Console</AssemblyName>


### PR DESCRIPTION
Starting from **.net5** Right to left Culture. Any string with "-1" will be printed "1-" (check the image below)

![image](https://user-images.githubusercontent.com/30401/134126302-5ece202f-63f6-4c94-b08c-e01ba37d32cd.png)

Also, the **hangfire/console** API expecting "-1" to stop polling logs. But it will never reach "-1". The server will send it "1-" (check the image below)

![image](https://user-images.githubusercontent.com/30401/134126499-974a6ccd-0a63-40ac-bf9b-98fcdee87983.png)
