### PR TITLE
fix: #125 Console Poll URL not respecting PathPrefix

### DIFF
--- a/src/Hangfire.Console/Dashboard/DynamicJsDispatcher.cs
+++ b/src/Hangfire.Console/Dashboard/DynamicJsDispatcher.cs
@@ -22,10 +22,12 @@ namespace Hangfire.Console.Dashboard
         {
             var builder = new StringBuilder();
 
+            var urlHelper = new UrlHelper(context);
+
             builder.Append(@"(function (hangfire) {")
                    .Append("hangfire.config = hangfire.config || {};")
                    .AppendFormat(CultureInfo.InvariantCulture, "hangfire.config.consolePollInterval = {0};", _options.PollInterval)
-                   .AppendFormat("hangfire.config.consolePollUrl = '{0}/console/';", context.Request.PathBase)
+                   .AppendFormat("hangfire.config.consolePollUrl = '{0}';", urlHelper.To("/console/"))
                    .Append("})(window.Hangfire = window.Hangfire || {});")
                    .AppendLine();
 


### PR DESCRIPTION
Fixes the console polling when using hangfire with the PathPrefix used to work with load balancers.

Closes the issue: #125 